### PR TITLE
Update gradient_validation.py

### DIFF
--- a/incompressible_flow/Inc_Species_Transport/3__gradient-validation/gradient_validation.py
+++ b/incompressible_flow/Inc_Species_Transport/3__gradient-validation/gradient_validation.py
@@ -30,7 +30,7 @@ meshName="primitiveVenturi.su2"
 
 # Note that correct SU2 version needs to be in PATH
 
-def_command = "SU2_DEF " + configMaster
+def_command = "mpirun -n " + ncores + " SU2_DEF " + configMaster
 cfd_command = "mpirun -n " + ncores + " SU2_CFD " + configMaster
 
 cfd_ad_command = "mpirun -n " + ncores + " SU2_CFD_AD " + configMaster


### PR DESCRIPTION
SU2_DEF exacutable also needs mpirun command like others (SU2_CFD, SU2_CFD_AD, SU2_DOT_AD)

Without mpirun command it gives error.